### PR TITLE
Provide benchmarks for setup time

### DIFF
--- a/avaje-config/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/avaje-config/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,24 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.avaje.config.Config;
+import io.avaje.config.Configuration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Configuration Avaje_Creation() {
+        return Config.asConfiguration();
+    }
+}

--- a/cfg4j/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/cfg4j/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,48 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.cfg4j.provider.ConfigurationProvider;
+import org.cfg4j.provider.ConfigurationProviderBuilder;
+import org.cfg4j.source.ConfigurationSource;
+import org.cfg4j.source.context.environment.Environment;
+import org.cfg4j.source.context.environment.ImmutableEnvironment;
+import org.cfg4j.source.context.filesprovider.ConfigFilesProvider;
+import org.cfg4j.source.files.FilesConfigurationSource;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public AppProps Cfg4j_Creation(BenchmarkState state) {
+      ConfigurationProvider configurationProvider = initCf4jConfigurationProvider();
+      return configurationProvider.bind("", AppProps.class);
+    }
+
+    private static ConfigurationProvider initCf4jConfigurationProvider() {
+      ConfigFilesProvider configFilesProvider =
+        () -> Arrays.asList(Paths.get("AppProps.properties"));
+
+      // Use local files as configuration store
+      ConfigurationSource source = new FilesConfigurationSource(configFilesProvider);
+
+      // Use relative paths
+      Environment environment = new ImmutableEnvironment("./build/resources/jmh/");
+      return new ConfigurationProviderBuilder()
+        .withConfigurationSource(source)
+        .withEnvironment(environment)
+        .build();
+    }
+}

--- a/coat/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/coat/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,34 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import de.poiu.coat.validation.ConfigValidationException;
+import java.io.IOException;
+import java.util.Properties;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+public abstract class BenchmarksSetup {
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+    }
+
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Config Coat_Creation(BenchmarkState state) throws ConfigValidationException, IOException {
+      final Properties props= new Properties();
+      props.load(Config.class.getResourceAsStream("/AppProps.properties"));
+      return ConfigBuilder.from(props);
+    }
+}

--- a/externalized-properties/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/externalized-properties/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,47 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy.externalizedproperties.core.ExternalizedProperties;
+import io.github.joeljeremy.externalizedproperties.core.resolvers.ResourceResolver;
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public AppProps EP_Creation(BenchmarkState state) throws IOException {
+      ExternalizedProperties externalizedProperties =
+        ExternalizedProperties.builder()
+          .defaults()
+          .resolvers(ResourceResolver.fromUrl(
+            getClass().getResource("/AppProps.properties")
+          ))
+          .build();
+
+      return externalizedProperties.initialize(AppProps.class);
+    }
+
+
+    @Benchmark
+    public ResolverFacadeProxy EP_CreationResolverFacade(BenchmarkState state) throws IOException {
+      ExternalizedProperties externalizedProperties =
+        ExternalizedProperties.builder()
+          .defaults()
+          .resolvers(ResourceResolver.fromUrl(
+            getClass().getResource("/AppProps.properties")
+          ))
+          .build();
+      return externalizedProperties.initialize(ResolverFacadeProxy.class);
+    }
+}

--- a/gestalt-config/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/gestalt-config/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,34 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.github.gestalt.config.Gestalt;
+import org.github.gestalt.config.builder.GestaltBuilder;
+import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.source.ClassPathConfigSource;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Gestalt GestaltConfig_Creation(BenchmarkState state) throws GestaltException {
+      final Gestalt gestalt = new GestaltBuilder()
+        .addDefaultConfigLoaders()
+        .addDefaultDecoders()
+        .addDefaultPostProcessors()
+        .addSource(new ClassPathConfigSource("/AppProps.properties"))
+        .build();
+      gestalt.loadConfigs();
+      return gestalt;
+    }
+}

--- a/lightbend-config/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/lightbend-config/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,25 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Config LightbendConfig_Creation(BenchmarkState state) {
+      return ConfigFactory.load("AppProps");
+    }
+}

--- a/microprofile-geronimo/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/microprofile-geronimo/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,34 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.geronimo.config.configsource.PropertyFileConfigSource;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Config MP_Geronimo_Creation(BenchmarkState state) {
+      return ConfigProviderResolver.instance()
+                .getBuilder()
+                .addDefaultSources()
+                .addDiscoveredSources()
+                .addDiscoveredConverters()
+                .withSources(new PropertyFileConfigSource(
+                    getClass().getResource("/AppProps.properties")
+                ))
+                .build();
+    }
+}

--- a/microprofile-helidon/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/microprofile-helidon/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,34 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import io.helidon.config.mp.MpConfigSources;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Config MP_Helidon_Creation(BenchmarkState state) {
+            return ConfigProviderResolver.instance()
+                .getBuilder()
+                .addDefaultSources()
+                .addDiscoveredSources()
+                .addDiscoveredConverters()
+                .withSources(MpConfigSources.create(
+                    getClass().getResource("/AppProps.properties")
+                ))
+                .build();
+    }
+}

--- a/microprofile-kumuluz-ee/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/microprofile-kumuluz-ee/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,35 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import com.kumuluz.ee.configuration.utils.ConfigurationImpl;
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Config MP_KumuluzEE_Creation(BenchmarkState state) {
+            System.setProperty("com.kumuluz.ee.configuration.file", "AppProps.properties");
+            ConfigurationUtil.initialize(new ConfigurationImpl());
+
+            return ConfigProviderResolver.instance()
+                .getBuilder()
+                .addDefaultSources()
+                .addDiscoveredSources()
+                .addDiscoveredConverters()
+                .build();
+    }
+}

--- a/microprofile-microbean/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/microprofile-microbean/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,34 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Config MP_MicroBean_Creation(BenchmarkState state) throws IOException {
+            return ConfigProviderResolver.instance()
+                .getBuilder()
+                .addDefaultSources()
+                .addDiscoveredSources()
+                .addDiscoveredConverters()
+                .withSources(new PropertiesFileConfigSource(
+                    getClass().getResource("/AppProps.properties")
+                ))
+                .build();
+    }
+}

--- a/microprofile-smallrye/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/microprofile-smallrye/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,35 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import io.smallrye.config.PropertiesConfigSource;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Config MP_SmallRye_Creation(BenchmarkState state) throws IOException {
+            return ConfigProviderResolver.instance()
+                .getBuilder()
+                .addDefaultSources()
+                .addDiscoveredSources()
+                .addDiscoveredConverters()
+                .withSources(new PropertiesConfigSource(
+                    getClass().getResource("/AppProps.properties")
+                ))
+                .build();
+    }
+}

--- a/owner/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/owner/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,23 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.aeonbits.owner.ConfigFactory;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+    @Benchmark
+    public AppProps Owner_Create(BenchmarkState state) {
+        return ConfigFactory.create(AppProps.class);
+    }
+}

--- a/spring-core/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
+++ b/spring-core/src/jmh/java/io/github/joeljeremy7/java/config/lib/benchmarks/BenchmarksSetup.java
@@ -1,0 +1,37 @@
+package io.github.joeljeremy7.java.config.lib.benchmarks;
+
+import io.github.joeljeremy7.java.config.lib.benchmarks.Benchmarks.BenchmarkState;
+import java.io.IOException;
+import java.util.Properties;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.TimeUnit;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+public abstract class BenchmarksSetup {
+
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class InitialCreation extends BenchmarksSetup {}
+
+
+
+    @Benchmark
+    public Environment SpringCore_Creation(BenchmarkState state) throws IOException {
+      Properties props = new Properties();
+      props.load(Benchmarks.class.getResourceAsStream("/AppProps.properties"));
+
+      ConfigurableEnvironment env = new StandardEnvironment();
+      env.getPropertySources().addFirst(
+        new PropertiesPropertySource("appProps", props)
+      );
+      return  env;
+    }
+
+}


### PR DESCRIPTION
You have to decide whether this change is interesting to you.

It tests the setup time of each library (the timespan that is explicitly excluded from the main tests).
While it is less important for most application, as all of them are usually fast enough, it may still be interesting to see these differences.

It uses JMHs SingleShotTime mode to be (hopefully) actually meaningful.

This PR depend on #36 to be merged first.